### PR TITLE
Add Docker image removal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ jobs:
         dotnet: true
         haskell: true
         large-packages: true
+        docker-images: true
         swap-storage: true
 ```
 ## Options
@@ -49,6 +50,7 @@ Here are a few sources of inspiration:
 - https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
 - https://github.com/ShubhamTatvamasi/free-disk-space-action
 - https://github.com/actions/virtual-environments/issues/2875#issuecomment-1163392159
+- https://github.com/easimon/maximize-build-space/
 
 ## Typical Output
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,11 @@ inputs:
     required: false
     default: "true"
 
+  docker-images:
+    description: "Remove Docker images"
+    required: false
+    default: "true"
+
   # option inspired by:
   # https://github.com/actions/virtual-environments/issues/2875#issuecomment-1163392159
   tool-cache:
@@ -178,6 +183,18 @@ runs:
           AFTER=$(getAvailableSpace)
           SAVED=$((AFTER-BEFORE))
           printSavedSpace $SAVED "Large misc. packages"
+        fi
+
+        # Option: Remove Docker images
+
+        if [[ ${{ inputs.docker-images }} == 'true' ]]; then
+          BEFORE=$(getAvailableSpace)
+
+          sudo docker image prune --all --force
+
+          AFTER=$(getAvailableSpace)
+          SAVED=$((AFTER-BEFORE))
+          printSavedSpace $SAVED "Docker images"
         fi
 
         # Option: Remove tool cache


### PR DESCRIPTION
This option enables removal of the pre-cached Docker images on the Runner image (e. g. https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#cached-docker-images).

As of today, this saves another 3.6 GB of disk space:

```noformat
...

Deleted Images:
untagged: node:16
untagged: node@sha256:550f484fc5f314b575f5e397c9e2c71d7f218e59729fcda9ffa7ea1fc825dce7
deleted: sha256:9b7ab79e69b7f7182ea6628f8c414d54d9f1f65f5ea76fb984774aecd4888b9c
deleted: sha256:dabfbc6620636484cda6a254dd2284c3cb688cbcc9d5e3669b780d072bc19ae5
deleted: sha256:ffe93337a34f6caa920f6199ed63e9a88cce685d9f67c6aa9ef7ab3d0a220c23
deleted: sha256:3b53a1104ae1f115157df6eebce35084106a2f1dbf9d55a261204f53cb507eaf
deleted: sha256:4c676a37369872479258ca5c8fa5ef9af168297e5d36a5bd6fba1f9faaa40801
untagged: alpine:3.17
deleted: sha256:1d12470fa662a2a5cb50378dcdc8ea228c1735747db410bbefb8e2d9144b5452
deleted: sha256:d7f4fb376c48badb9879c97df87580480be3f4dcad2e2f33425792d164933fa3
deleted: sha256:71fe964a0bdce3b1795d90eb1f8a501dd719e8612faeb40783706c962339c75c
deleted: sha256:559303f34408584d79e77eab1ec15eb80d04d753a87a38c8da31542440c0a64a
deleted: sha256:483ca60b49ed28025355f381d9e2b759e67e66b9dfb266c66f57acf0cb47033e
deleted: sha256:f1edb12649962bbc5048b132c2201e98d474b9f99e6936d41633b43d6e7bd91d
deleted: sha256:9f9d995a1674f94b553c90e4eb3502db04a8220403f3add46486659752a3a108
deleted: sha256:a61e818f0b1f7522e3a27211026f564f1fd98ae2034229d1233623e92a6a7961
deleted: sha256:16c88c4e67dd8ed4c67c0e9c1dae7df697f4607eab4c3d2f12b1b18206a6a6e4
deleted: sha256:b2dba74777543b60e1a5be6da44e67659f51b8df1e96922205a5dde6b92dda3c
untagged: ubuntu:18.04
untagged: ubuntu@sha256:8aa9c2798215f99544d1ce7439ea9c3a6dfd82de607da1cec3a8a2fae005931b
deleted: sha256:3941d3b032a8168d53508410a67baad120a563df67a7959565a30a1cb2114731
deleted: sha256:b7e0fa7bfe7f9796f1268cca2e65a8bfb1e010277652cee9a9c9d077a83db3c4
untagged: alpine:3.14
untagged: alpine@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed
deleted: sha256:9e179bacf43c4d3428d57cf459799ba0285b901945f9eccb17b6da056d3532c7
deleted: sha256:9733ccc395133a067f01ee6e380003d80fe9f443673e0f992ae6a4a7860a872c
untagged: node:16-alpine
untagged: node@sha256:f1657204d3463bce763cefa5b25e48c28af6fe0cdb0f68b354f0f8225ef61be7
deleted: sha256:8cf71856f96e5777c57c2318ecbcba52070b2c5a30c9a068db22a32f58a74c5c
deleted: sha256:4e2825237d762be00ce5e62f36aa55b7447ea4cf668d380c4f073bb97dde6a8e
deleted: sha256:4c9f7fc715d445d4480f8b1f5278cee0e53843207cc6fefc3921b6bb87d832fa
deleted: sha256:879ee36c8017c1ab8054048113851ff4af3858ea35933f7cbf5b5fa720d24d6b
deleted: sha256:f1417ff83b319fbdae6dd9cd6d8c9c88002dcd75ecf6ec201c8c6894681cf2b5
untagged: buildpack-deps:buster
untagged: buildpack-deps@sha256:bfefe2afb02a82c76d955f2c158b3b5aa96e7afcf262727e8f37ccdea60a39c5
deleted: sha256:3f4a705ee51073aee134dae0f28c1b9e1d9b007b6637b42762d5bccd8206567b
deleted: sha256:166fc1eedb4f224adf46b88c146c5a8e6cd878ca9919a693a86f093be4fe9a94
deleted: sha256:e6ce27ea3bf053007173e2edbd5149a7386e9837c30a2fc6e8d493aee262bb74
deleted: sha256:613af40da8f9499a7f5ab87cf0ab1e609451a8d1173c4ab763b4a452a84b2548
deleted: sha256:f689d32da26171a93595fff5d705c775d7124c191ca34a5ec1ac55a5e746630f
untagged: debian:11
untagged: debian@sha256:63d62ae233b588d6b426b7b072d79d1306bfd02a72bff1fc045b8511cc89ee09
deleted: sha256:34b4fa67dc04381e908b662ed69b3dbe8015fa723a746c66cc870a5330520981
deleted: sha256:d925e0fae4e6e7ecb7df154c4cd812ea2956afa744bb6de32ea41850000fb25c
untagged: alpine:3.15
untagged: alpine@sha256:ecbdce53b2c2f43ab1b19418bcbd3f120a23547d9497030c8d978114512b883e
deleted: sha256:58c0644b45ff503f1b05dc272ce691659daf2ea2c940bd18e7efbf30f93427f7
deleted: sha256:49f62469da7651bcaf2d76af7a56680c2dd9b7cf177ead3e8a675b160500b68e

Total reclaimed space: 3.605GB

********************************************************************************
=> Docker images: Saved 3.6GiB
********************************************************************************

...
```