### PR TITLE
Select alternative apt mirror to get around the unstable original one

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -171,6 +171,11 @@ runs:
 
         if [[ ${{ inputs.large-packages }} == 'true' ]]; then
           BEFORE=$(getAvailableSpace)
+
+          # Select alternative apt mirror since the original one is unstable
+          sudo gem install apt-spy2
+          sudo apt-spy2 fix --commit --launchpad --country=US
+          sudo apt-get update
           
           sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
           sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: "Allow use of alternative apt mirrors"
     required: false
     default: "false"
+  apt-mirror-country:
+    description: "Location of the apt mirror to use (if using GitHub cloud runners, select 'US')"
+    required: false
+    default: "US"
 
 runs:
   using: "composite"
@@ -180,7 +184,7 @@ runs:
           if [[ ${{ inputs.allow-apt-mirrors }} == 'true' ]]; then
             # Select alternative apt mirror
             sudo gem install apt-spy2
-            sudo apt-spy2 fix --commit --launchpad --country=US
+            sudo apt-spy2 fix --commit --launchpad --country=${{ inputs.apt-mirror-country }}
             sudo apt-get update
           fi
           

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,11 @@ inputs:
     required: false
     default: "true"
 
+  allow-apt-mirrors:
+    description: "Allow use of alternative apt mirrors"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -172,10 +177,12 @@ runs:
         if [[ ${{ inputs.large-packages }} == 'true' ]]; then
           BEFORE=$(getAvailableSpace)
 
-          # Select alternative apt mirror since the original one is unstable
-          sudo gem install apt-spy2
-          sudo apt-spy2 fix --commit --launchpad --country=US
-          sudo apt-get update
+          if [[ ${{ inputs.allow-apt-mirrors }} == 'true' ]]; then
+            # Select alternative apt mirror
+            sudo gem install apt-spy2
+            sudo apt-spy2 fix --commit --launchpad --country=US
+            sudo apt-get update
+          fi
           
           sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
           sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."


### PR DESCRIPTION
This should fix #4.

Since this issue hits me in about every month's time, I ran a quick research on the root cause (e.g. https://github.com/actions/runner-images/issues/7048).

The downside of this solution is clearly that we rely on an extra package (`apt-spy2`). That installation and the repository update take a few additional seconds to complete. But in my very personal case, the gained resiliency is definitely worth it.

Log excerpt of an example run:

```
...

Successfully installed thor-1.2.2
Successfully installed nokogiri-1.14.5-x86_64-linux
Successfully installed apt-spy2-0.8.2
Parsing documentation for thor-1.2.2
Installing ri documentation for thor-1.2.2
Parsing documentation for nokogiri-1.14.5-x86_64-linux
Installing ri documentation for nokogiri-1.14.5-x86_64-linux
Parsing documentation for apt-spy2-0.8.2
Installing ri documentation for apt-spy2-0.8.2
Done installing documentation for thor, nokogiri, apt-spy2 after 3 seconds
3 gems installed
The closest mirror is: https://mirror.enzu.com/ubuntu/
Updating /etc/apt/sources.list
Updated '/etc/apt/sources.list' with https://mirror.enzu.com/ubuntu/
Run `apt-get update` to update
Get:1 https://packages.microsoft.com/ubuntu/22.04/prod jammy InRelease [3611 B]
Get:2 https://packages.microsoft.com/ubuntu/22.04/prod jammy/main arm64 Packages [14.7 kB]
Get:3 https://packages.microsoft.com/ubuntu/22.04/prod jammy/main armhf Packages [7897 B]
Get:4 https://packages.microsoft.com/ubuntu/22.04/prod jammy/main amd64 Packages [69.1 kB]
Get:5 https://mirror.enzu.com/ubuntu jammy InRelease [270 kB]
Hit:6 https://ppa.launchpadcontent.net/ubuntu-toolchain-r/test/ubuntu jammy InRelease
Get:7 https://mirror.enzu.com/ubuntu jammy-updates InRelease [114 kB]
Get:8 https://mirror.enzu.com/ubuntu jammy-backports InRelease [99.8 kB]
Get:9 https://mirror.enzu.com/ubuntu jammy-security InRelease [110 kB]
Get:10 https://mirror.enzu.com/ubuntu jammy/main amd64 Packages [1395 kB]
Get:11 https://mirror.enzu.com/ubuntu jammy/main Translation-en [510 kB]
Get:12 https://mirror.enzu.com/ubuntu jammy/main amd64 c-n-f Metadata [30.3 kB]
Get:13 https://mirror.enzu.com/ubuntu jammy/restricted amd64 Packages [129 kB]
Get:14 https://mirror.enzu.com/ubuntu jammy/restricted Translation-en [18.6 kB]
Get:15 https://mirror.enzu.com/ubuntu jammy/restricted amd64 c-n-f Metadata [488 B]
Get:16 https://mirror.enzu.com/ubuntu jammy/universe amd64 Packages [14.1 MB]
Get:17 https://mirror.enzu.com/ubuntu jammy/universe Translation-en [5652 kB]
Get:18 https://mirror.enzu.com/ubuntu jammy/universe amd64 c-n-f Metadata [286 kB]
Get:19 https://mirror.enzu.com/ubuntu jammy/multiverse amd64 Packages [217 kB]
Get:20 https://mirror.enzu.com/ubuntu jammy/multiverse Translation-en [112 kB]
Get:21 https://mirror.enzu.com/ubuntu jammy/multiverse amd64 c-n-f Metadata [8372 B]
Get:22 https://mirror.enzu.com/ubuntu jammy-updates/main amd64 Packages [839 kB]
Get:23 https://mirror.enzu.com/ubuntu jammy-updates/main Translation-en [186 kB]
Get:24 https://mirror.enzu.com/ubuntu jammy-updates/main amd64 c-n-f Metadata [12.3 kB]
Get:25 https://mirror.enzu.com/ubuntu jammy-updates/restricted amd64 Packages [566 kB]
Get:26 https://mirror.enzu.com/ubuntu jammy-updates/restricted Translation-en [87.1 kB]
Get:27 https://mirror.enzu.com/ubuntu jammy-updates/restricted amd64 c-n-f Metadata [556 B]
Get:28 https://mirror.enzu.com/ubuntu jammy-updates/universe amd64 Packages [792 kB]
Get:29 https://mirror.enzu.com/ubuntu jammy-updates/universe Translation-en [139 kB]
Get:30 https://mirror.enzu.com/ubuntu jammy-updates/universe amd64 c-n-f Metadata [14.9 kB]
Get:31 https://mirror.enzu.com/ubuntu jammy-updates/multiverse amd64 Packages [7988 B]
Get:32 https://mirror.enzu.com/ubuntu jammy-updates/multiverse Translation-en [2448 B]
Get:33 https://mirror.enzu.com/ubuntu jammy-updates/multiverse amd64 c-n-f Metadata [432 B]
Get:34 https://mirror.enzu.com/ubuntu jammy-backports/main amd64 Packages [3324 B]
Get:35 https://mirror.enzu.com/ubuntu jammy-backports/main Translation-en [1580 B]
Get:36 https://mirror.enzu.com/ubuntu jammy-backports/main amd64 c-n-f Metadata [272 B]
Get:37 https://mirror.enzu.com/ubuntu jammy-backports/restricted amd64 c-n-f Metadata [116 B]
Get:38 https://mirror.enzu.com/ubuntu jammy-backports/universe amd64 Packages [6744 B]
Get:39 https://mirror.enzu.com/ubuntu jammy-backports/universe Translation-en [9460 B]
Get:40 https://mirror.enzu.com/ubuntu jammy-backports/universe amd64 c-n-f Metadata [352 B]
Get:41 https://mirror.enzu.com/ubuntu jammy-backports/multiverse amd64 c-n-f Metadata [116 B]
Get:42 https://mirror.enzu.com/ubuntu jammy-security/main amd64 Packages [593 kB]
Get:43 https://mirror.enzu.com/ubuntu jammy-security/main Translation-en [125 kB]
Get:44 https://mirror.enzu.com/ubuntu jammy-security/main amd64 c-n-f Metadata [7800 B]
Get:45 https://mirror.enzu.com/ubuntu jammy-security/restricted amd64 Packages [528 kB]
Get:46 https://mirror.enzu.com/ubuntu jammy-security/restricted Translation-en [81.2 kB]
Get:47 https://mirror.enzu.com/ubuntu jammy-security/restricted amd64 c-n-f Metadata [556 B]
Get:48 https://mirror.enzu.com/ubuntu jammy-security/universe amd64 Packages [634 kB]
Get:49 https://mirror.enzu.com/ubuntu jammy-security/universe Translation-en [86.4 kB]
Get:50 https://mirror.enzu.com/ubuntu jammy-security/universe amd64 c-n-f Metadata [11.3 kB]
Get:51 https://mirror.enzu.com/ubuntu jammy-security/multiverse amd64 Packages [4268 B]
Get:52 https://mirror.enzu.com/ubuntu jammy-security/multiverse Translation-en [972 B]
Get:53 https://mirror.enzu.com/ubuntu jammy-security/multiverse amd64 c-n-f Metadata [228 B]
Fetched 27.9 MB in 5s (6101 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package 'dotnet-nightly' is not installed, so not removed
Package 'dotnet-targeting-pack-3.1' is not installed, so not removed
Package 'dotnet-sdk-6.0-source-built-artifacts' is not installed, so not removed
Package 'dotnet-templates-6.0' is not installed, so not removed
Package 'dotnet-apphost-pack-3.1' is not installed, so not removed
Package 'dotnet-runtime-3.1' is not installed, so not removed
Package 'dotnet-sdk-3.1' is not installed, so not removed
Package 'dotnet-hostfxr-3.1' is not installed, so not removed
Package 'dotnet-runtime-deps-3.1' is not installed, so not removed
The following additional packages will be installed:
  aspnetcore-targeting-pack-6.0
The following packages will be REMOVED:
  aspnetcore-runtime-6.0 aspnetcore-runtime-7.0 aspnetcore-targeting-pack-7.0
  dotnet-apphost-pack-6.0 dotnet-apphost-pack-7.0 dotnet-host
  dotnet-hostfxr-6.0 dotnet-hostfxr-7.0 dotnet-runtime-6.0 dotnet-runtime-7.0
  dotnet-runtime-deps-6.0 dotnet-runtime-deps-7.0 dotnet-sdk-6.0
  dotnet-sdk-7.0 dotnet-targeting-pack-6.0 dotnet-targeting-pack-7.0
The following packages will be upgraded:
  aspnetcore-targeting-pack-6.0
1 upgraded, 0 newly installed, 16 to remove and 20 not upgraded.
Need to get 1455 kB of archives.
After this operation, 1002 MB disk space will be freed.
Get:1 https://mirror.enzu.com/ubuntu jammy-updates/universe amd64 aspnetcore-targeting-pack-6.0 amd64 6.0.113-0ubuntu1~22.04.1 [1455 kB]
Fetched 1455 kB in 1s (1792 kB/s)

...
```

I hope, this helps others too.