### PR TITLE
Fix the issue.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -170,7 +170,8 @@ runs:
 
         if [[ ${{ inputs.large-packages }} == 'true' ]]; then
           BEFORE=$(getAvailableSpace)
-
+          
+          sudo apt-get update
           sudo apt-get remove -y '^dotnet-.*'
           sudo apt-get remove -y '^llvm-.*'
           sudo apt-get remove -y 'php.*'


### PR DESCRIPTION
The script will first run apt get update to update the software package list, and then run apt get remove - y '^ dotnet -. *' to fix the issue of executing errors based on rm rf/usr/share/dotnet