### PR TITLE
Fix for google-cloud-sdk renamed to google-cloud-cli

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,14 @@
 name: Free Disk Space (Ubuntu)
-on: push
-workflow_dispatch:
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+  workflow_dispatch:
+    branches:
+      - '*'
 
 jobs:
   free-disk-space:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,11 @@
 name: Free Disk Space (Ubuntu)
 on:
   push:
-    branches:
-      - '*'
+    branches: [ main ]
   pull_request:
-    branches:
-      - '*'
+    branches: [ main ]
   workflow_dispatch:
-    branches:
-      - '*'
+    branches: [ main ]
 
 jobs:
   free-disk-space:
@@ -16,7 +13,7 @@ jobs:
     steps:
       # If there is a problem with this GitHub Actions, this step will fail
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: ${{ github.actor }}/free-disk-space@main
         with:
           tool-cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,5 @@
 name: Free Disk Space (Ubuntu)
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_dispatch:
-    branches: [ main ]
+on: push
 
 jobs:
   free-disk-space:
@@ -13,7 +7,7 @@ jobs:
     steps:
       # If there is a problem with this GitHub Actions, this step will fail
       - name: Free Disk Space
-        uses: ${{ github.actor }}/free-disk-space@main
+        uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: Free Disk Space (Ubuntu)
 on: push
+workflow_dispatch:
 
 jobs:
   free-disk-space:

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^mongodb-.*'
           sudo apt-get remove -y '^mysql-.*'
-          sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get remove -y azure-cli google-cloud-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           sudo apt-get autoremove -y
           sudo apt-get clean
           


### PR DESCRIPTION
Fixes #17.

Tried improving the test CI as well, but in the end it did not work, so the only modification in this PR is the renaming of the `google-cloud-sdk` package.