### PR TITLE
Remove .ghcup from different directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -159,6 +159,8 @@ runs:
           BEFORE=$(getAvailableSpace)
 
           sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+
           
           AFTER=$(getAvailableSpace)
           SAVED=$((AFTER-BEFORE))


### PR DESCRIPTION
I noticed that `/opt/ghc` does not exist on my GHA containers, however, `/usr/local/.ghcup` does and contains quite a bit of large files.