### PR TITLE
Remove haskell from different directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -159,6 +159,7 @@ runs:
           BEFORE=$(getAvailableSpace)
 
           sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
           
           AFTER=$(getAvailableSpace)
           SAVED=$((AFTER-BEFORE))


### PR DESCRIPTION
I noticed that `/opt/ghc` does not exist on my GHA workers, however, `/usr/local/.ghcup` does and contains quite a bit of large files.