### PR TITLE
perf: speed up deletings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,19 @@ runs:
         # ======
         # MACROS
         # ======
+        
+        fast_rmdir() {
+          if [[ -d "$1" ]] && [[ -n "$1" ]] && [[ ! "$1" = "/" ]] && [[ ! "$1" = "~" ]]; then
+            echo "Removing directory: $1"
+            _tmp=$(mktemp -d)
+            sudo rsync -r -delete --delete-after --info=STATS2 "${_tmp}/" "$1/"
+            sudo rm -rf "$1" "$_tmp"
+          fi
+        }
+
+        list_installed_dpkg() {
+          dpkg --get-selections $@ | grep -v deinstall | awk '{print $1}'
+        }
 
         # macro to print a line of equals
         # (silly but works)
@@ -133,7 +146,7 @@ runs:
         if [[ ${{ inputs.android }} == 'true' ]]; then
           BEFORE=$(getAvailableSpace)
           
-          sudo rm -rf /usr/local/lib/android || true
+          fast_rmdir /usr/local/lib/android || true
 
           AFTER=$(getAvailableSpace)
           SAVED=$((AFTER-BEFORE))
@@ -146,7 +159,7 @@ runs:
           BEFORE=$(getAvailableSpace)
 
           # https://github.community/t/bigger-github-hosted-runners-disk-space/17267/11
-          sudo rm -rf /usr/share/dotnet || true
+          fast_rmdir /usr/share/dotnet || true
           
           AFTER=$(getAvailableSpace)
           SAVED=$((AFTER-BEFORE))
@@ -158,8 +171,8 @@ runs:
         if [[ ${{ inputs.haskell }} == 'true' ]]; then
           BEFORE=$(getAvailableSpace)
 
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/.ghcup || true
+          fast_rmdir /opt/ghc || true
+          fast_rmdir /usr/local/.ghcup || true
           
           AFTER=$(getAvailableSpace)
           SAVED=$((AFTER-BEFORE))
@@ -171,17 +184,24 @@ runs:
 
         if [[ ${{ inputs.large-packages }} == 'true' ]]; then
           BEFORE=$(getAvailableSpace)
-          
-          sudo apt-get remove -y '^aspnetcore-.*' || echo "::warning::The command [sudo apt-get remove -y '^aspnetcore-.*'] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y '^dotnet-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^dotnet-.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y '^llvm-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^llvm-.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y 'php.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y 'php.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y '^mongodb-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mongodb-.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y '^mysql-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mysql-.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y google-cloud-sdk --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-sdk --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y google-cloud-cli --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-cli --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed to complete successfully. Proceeding..."
+
+          pkgs=$(list_installed_dpkg 'aspnetcore-*' 'dotnet-*' 'llvm-*' '*php*' 'mongodb-*' 'mysql-*' azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri 'google-cloud-*' 'gcloud-*' || true)
+
+          gcloud_prerm='#!/bin/sh
+          echo $0
+          if [ -d "/usr/lib/google-cloud-sdk" ]; then
+            _tmp=$(mktemp -d)
+            echo "Cleaning Google Cloud CLI files..."
+            rsync -r -delete --delete-after --info=STATS2 "${_tmp}/" /usr/lib/google-cloud-sdk/
+            rm -rf /usr/lib/google-cloud-sdk "$_tmp"
+            echo "Cleaning Google Cloud CLI manuals..."
+            find /usr/share/man -type f -name "gcloud*" -delete -print | wc -l
+          fi'
+
+          echo "$gcloud_prerm" | sudo tee /var/lib/dpkg/info/google-cloud-cli-anthoscli.prerm >/dev/null
+          echo "$gcloud_prerm" | sudo tee /var/lib/dpkg/info/google-cloud-cli.prerm >/dev/null
+
+          sudo apt-get remove --autoremove -y $pkgs || echo "::warning::The command [sudo apt-get remove -y] failed to complete successfully. Proceeding..."
           sudo apt-get clean || echo "::warning::The command [sudo apt-get clean] failed to complete successfully. Proceeding..."
 
           AFTER=$(getAvailableSpace)
@@ -207,7 +227,7 @@ runs:
         if [[ ${{ inputs.tool-cache }} == 'true' ]]; then
           BEFORE=$(getAvailableSpace)
 
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+          fast_rmdir "$AGENT_TOOLSDIRECTORY" || true
           
           AFTER=$(getAvailableSpace)
           SAVED=$((AFTER-BEFORE))

--- a/action.yml
+++ b/action.yml
@@ -57,9 +57,8 @@ runs:
         fast_rmdir() {
           if [[ -d "$1" ]] && [[ -n "$1" ]] && [[ ! "$1" = "/" ]] && [[ ! "$1" = "~" ]]; then
             echo "Removing directory: $1"
-            _tmp=$(mktemp -d)
-            sudo rsync -r -delete --delete-after --info=STATS2 "${_tmp}/" "$1/"
-            sudo rm -rf "$1" "$_tmp"
+            sudo find "$1" -type f -delete -print | wc -l
+            sudo rm -rf "$1"
           fi
         }
 
@@ -190,10 +189,9 @@ runs:
           gcloud_prerm='#!/bin/sh
           echo $0
           if [ -d "/usr/lib/google-cloud-sdk" ]; then
-            _tmp=$(mktemp -d)
             echo "Cleaning Google Cloud CLI files..."
-            rsync -r -delete --delete-after --info=STATS2 "${_tmp}/" /usr/lib/google-cloud-sdk/
-            rm -rf /usr/lib/google-cloud-sdk "$_tmp"
+            find /usr/lib/google-cloud-sdk -type f -delete -print | wc -l
+            rm -rf /usr/lib/google-cloud-sdk
             echo "Cleaning Google Cloud CLI manuals..."
             find /usr/share/man -type f -name "gcloud*" -delete -print | wc -l
           fi'


### PR DESCRIPTION
Reducing the execution time of the workflow to under 1 minute.

- Use `find -delete` instead of `rm -rf` to speed up deleting large amount files.
- Optimize prerm script of `google-cloud-cli`

| Before  | After |
| --- | --- |
| 1m52s | 46s |
|  ![image](https://github.com/user-attachments/assets/bf063b10-a982-4f8c-832a-a7d11f9ecad5) |  ![image](https://github.com/user-attachments/assets/5282b5b0-c7d5-4318-825d-4fbdeee9285b) |
