### PR TITLE
Update action.yml, README.md - refactor dh » df

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ The log output of a typical example (with all options set to `true`) looks like 
 ================================================================================
 BEFORE CLEAN-UP:
 
-$ dh -h /
+$ df -h /
 
 Filesystem      Size  Used Avail Use% Mounted on
 /dev/root        84G   53G   31G  64% /
-$ dh -a /
+$ df -a /
 
 Filesystem     1K-blocks     Used Available Use% Mounted on
 /dev/root       87218124 55405432  31796308  64% /
-$ dh -a
+$ df -a
 
 Filesystem     1K-blocks     Used Available Use% Mounted on
 /dev/root       87218124 55405432  31796308  64% /
@@ -1574,15 +1574,15 @@ Swap:            0B          0B          0B
 ================================================================================
 AFTER CLEAN-UP:
 
-$ dh -h /
+$ df -h /
 
 Filesystem      Size  Used Avail Use% Mounted on
 /dev/root        84G   26G   58G  31% /
-$ dh -a /
+$ df -a /
 
 Filesystem     1K-blocks     Used Available Use% Mounted on
 /dev/root       87218124 26471028  60730712  31% /
-$ dh -a
+$ df -a
 
 Filesystem     1K-blocks     Used Available Use% Mounted on
 /dev/root       87218124 26471028  60730712  31% /

--- a/action.yml
+++ b/action.yml
@@ -94,20 +94,20 @@ runs:
           echo ""
         }
 
-        # macro to print output of dh with caption
-        printDH() {
+        # macro to print output of df with caption
+        printDF() {
           caption=${1:-}
 
           printSeparationLine '=' 80
           echo "${caption}"
           echo ""
-          echo "$ dh -h /"
+          echo "$ df -h /"
           echo ""
           df -h /
-          echo "$ dh -a /"
+          echo "$ df -a /"
           echo ""
           df -a /
-          echo "$ dh -a"
+          echo "$ df -a"
           echo ""
           df -a
           printSeparationLine '=' 80
@@ -124,7 +124,7 @@ runs:
         AVAILABLE_INITIAL=$(getAvailableSpace)
         AVAILABLE_ROOT_INITIAL=$(getAvailableSpace '/')
 
-        printDH "BEFORE CLEAN-UP:"
+        printDF "BEFORE CLEAN-UP:"
         echo ""
 
 
@@ -236,7 +236,7 @@ runs:
         AVAILABLE_ROOT_END=$(getAvailableSpace '/')
 
         echo ""
-        printDH "AFTER CLEAN-UP:"
+        printDF "AFTER CLEAN-UP:"
 
         echo ""
         echo ""


### PR DESCRIPTION
rename `dh` occurences with `df` which I assume is a typo

- since the commands are echo'd out I thought it would make sense to match the commands they're referencing
- I also renamed the bash functions to match the replacement
