### PR TITLE
fix: isolate google-chrome-stable package removal to prevent skipping other packages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -178,9 +178,10 @@ runs:
           sudo apt-get remove -y 'php.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y 'php.*' --fix-missing] failed to complete successfully. Proceeding..."
           sudo apt-get remove -y '^mongodb-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mongodb-.*' --fix-missing] failed to complete successfully. Proceeding..."
           sudo apt-get remove -y '^mysql-.*' --fix-missing || echo "::warning::The command [sudo apt-get remove -y '^mysql-.*' --fix-missing] failed to complete successfully. Proceeding..."
-          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y azure-cli firefox powershell mono-devel libgl1-mesa-dri --fix-missing || echo "::warning::The command [sudo apt-get remove -y azure-cli firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding..."
           sudo apt-get remove -y google-cloud-sdk --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-sdk --fix-missing] failed to complete successfully. Proceeding..."
           sudo apt-get remove -y google-cloud-cli --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-cloud-cli --fix-missing] failed to complete successfully. Proceeding..."
+          sudo apt-get remove -y google-chrome-stable --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-chrome-stable --fix-missing] failed to complete successfully. Proceeding..."
           sudo apt-get autoremove -y || echo "::warning::The command [sudo apt-get autoremove -y] failed to complete successfully. Proceeding..."
           sudo apt-get clean || echo "::warning::The command [sudo apt-get clean] failed to complete successfully. Proceeding..."
 


### PR DESCRIPTION
## Problem Description

In Ubuntu 24.04 LTS Arm environments, the `google-chrome-stable` package does not exist, which causes the entire `apt-get remove` command containing this package to fail, thereby skipping the removal of other packages.

As shown in the error log from issue #41:
```
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package google-chrome-stable
Warning: The command [sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing] failed to complete successfully. Proceeding...
```

## Solution

This PR isolates `google-chrome-stable` from the multi-package removal command, following the same approach used for `google-cloud-sdk` and `google-cloud-cli`.

### Changes Made

1. **Remove `google-chrome-stable` from the multi-package command**:
   ```bash
   # Before
   sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri --fix-missing
   
   # After  
   sudo apt-get remove -y azure-cli firefox powershell mono-devel libgl1-mesa-dri --fix-missing
   ```

2. **Add individual `google-chrome-stable` removal command**:
   ```bash
   sudo apt-get remove -y google-chrome-stable --fix-missing || echo "::debug::The command [sudo apt-get remove -y google-chrome-stable --fix-missing] failed to complete successfully. Proceeding..."
   ```

### Benefits

- ✅ Prevents single package failures from affecting other package removals
- ✅ Uses `::debug::` level error handling, consistent with other Google packages
- ✅ Maintains backward compatibility
- ✅ Improves stability across different Ubuntu versions and architectures

## Testing

The modified code has correct YAML syntax and follows the same logic as existing `google-cloud-sdk` and `google-cloud-cli` handling.

## Related Issue

Resolves #41